### PR TITLE
Fix problem when using base HTML tag

### DIFF
--- a/src/Binarix/FoundationPagination/FoundationPresenter.php
+++ b/src/Binarix/FoundationPagination/FoundationPresenter.php
@@ -46,7 +46,7 @@ class FoundationPresenter extends BootstrapPresenter {
         // when that is the case. Otherwise, we will give it an active "status".
         if ($this->currentPage <= 1)
         {
-            return '<li class="arrow unavailable"><a href="#">'.$text.'</a></li>';
+            return '<li class="arrow unavailable"><a>'.$text.'</a></li>';
         }
         else
         {
@@ -69,7 +69,7 @@ class FoundationPresenter extends BootstrapPresenter {
         // that is available, so we will make it the "next" link style disabled.
         if ($this->currentPage >= $this->lastPage)
         {
-            return '<li class="arrow unavailable"><a href="#">'.$text.'</a></li>';
+            return '<li class="arrow unavailable"><a>'.$text.'</a></li>';
         }
         else
         {


### PR DESCRIPTION
This fixes a problem when your html document uses the [HTML base tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base). If you are in the first or last page and you click the "&laquo; previous" or "next &raquo;" link, respectively, you will be redirected to the main page of your site.

Steps to reproduce:
#### 1.- Add HTML base tag to your layout

``` html
<!DOCTYPE html>
<html>
    <head>
        ...
        <base href="..." />
        ...
    </head>
    <body>
        ...
    </body>
</html>
```
#### 2.- Click Previous or Next link in one of the edges of the pagination

Visit the first page and click the pagination previous (&laquo;) link or visit the last page and click the next (&raquo;) link.

You will be sent to the home page of your site.

---

IMHO makes no sense to show the the previous (&laquo;) link when you are in the first page (or same for the next &raquo; link and the last page) but I understand this is just my personal taste so I decided to keep them in the PR.
